### PR TITLE
fixing error where image doesn't exist

### DIFF
--- a/roles/build_creationee/tasks/main.yml
+++ b/roles/build_creationee/tasks/main.yml
@@ -8,7 +8,7 @@
   loop:
     - "{{ ee_base_image }}"
     # - "{{ ee_builder_image }}"
-  when: ee_version == 1
+  #when: ee_version == 1
 
 - name: Login to PAH
   containers.podman.podman_login:


### PR DESCRIPTION
ansible-builder can't do it's "first" build because the image never get's pulled when version != 1.