### PR TITLE
lennysh-add-collection-type

### DIFF
--- a/roles/build_creationee/templates/requirements.yml.j2
+++ b/roles/build_creationee/templates/requirements.yml.j2
@@ -13,6 +13,9 @@ roles:
 collections:
 {% for item in ee_collections %}
 - name: {{ item.name }}
+{% if item.type is defined %}
+  type: {{ item.type }}
+{% endif %}
 {% if item.version is defined %}
   version: {{ item.version }}
 {% endif %}

--- a/roles/build_middlewareee/templates/requirements.yml.j2
+++ b/roles/build_middlewareee/templates/requirements.yml.j2
@@ -13,6 +13,9 @@ roles:
 collections:
 {% for item in ee_collections %}
 - name: {{ item.name }}
+{% if item.type is defined %}
+  type: {{ item.type }}
+{% endif %}
 {% if item.version is defined %}
   version: {{ item.version }}
 {% endif %}

--- a/roles/build_shadowmande/templates/requirements.yml.j2
+++ b/roles/build_shadowmande/templates/requirements.yml.j2
@@ -13,6 +13,9 @@ roles:
 collections:
 {% for item in ee_collections %}
 - name: {{ item.name }}
+{% if item.type is defined %}
+  type: {{ item.type }}
+{% endif %}
 {% if item.version is defined %}
   version: {{ item.version }}
 {% endif %}

--- a/roles/build_shadowmandevspaces/templates/requirements.yml.j2
+++ b/roles/build_shadowmandevspaces/templates/requirements.yml.j2
@@ -13,6 +13,9 @@ roles:
 collections:
 {% for item in ee_collections %}
 - name: {{ item.name }}
+{% if item.type is defined %}
+  type: {{ item.type }}
+{% endif %}
 {% if item.version is defined %}
   version: {{ item.version }}
 {% endif %}

--- a/roles/build_shadowmanee/templates/requirements.yml.j2
+++ b/roles/build_shadowmanee/templates/requirements.yml.j2
@@ -13,6 +13,9 @@ roles:
 collections:
 {% for item in ee_collections %}
 - name: {{ item.name }}
+{% if item.type is defined %}
+  type: {{ item.type }}
+{% endif %}
 {% if item.version is defined %}
   version: {{ item.version }}
 {% endif %}

--- a/roles/build_terraformpowershellee/templates/requirements.yml.j2
+++ b/roles/build_terraformpowershellee/templates/requirements.yml.j2
@@ -13,6 +13,9 @@ roles:
 collections:
 {% for item in ee_collections %}
 - name: {{ item.name }}
+{% if item.type is defined %}
+  type: {{ item.type }}
+{% endif %}
 {% if item.version is defined %}
   version: {{ item.version }}
 {% endif %}


### PR DESCRIPTION
I needed a collection that could only be downloaded from Git and noticed you didn't have `type:` in there.  I am adding it in case anybody else in the future needs the same.